### PR TITLE
fix: Don't shaddow locals when running exec

### DIFF
--- a/python-scripter.py
+++ b/python-scripter.py
@@ -89,8 +89,7 @@ class BurpExtender(IBurpExtender, ISessionHandlingAction, IExtensionStateListene
         if not self.checkboxEnable.isSelected():
             return
         try:
-            globals_ = {}
-            locals_  = {'extender': self,
+            globals_  = {'extender': self,
                         'callbacks': self.callbacks,
                         'helpers': self.helpers,
                         'toolFlag': toolFlag,
@@ -98,7 +97,7 @@ class BurpExtender(IBurpExtender, ISessionHandlingAction, IExtensionStateListene
                         'messageInfo': messageInfo,
                         'macroItems': macroItems
                         }
-            exec(self.script, globals_, locals_)
+            exec(self.script, globals_)
         except Exception:
             traceback.print_exc(file=self.callbacks.getStderr())
         return


### PR DESCRIPTION
When you pass the locals arg to exec you overwrite/shaddow the locals compiled into the code object.

This results in NameErrors like:
```
Traceback (most recent call last):
  File "test.py", line 12, in <module>
    exec(compiled_code, {}, {})
  File "<script>", line 8, in <module>
  File "<script>", line 6, in bar
NameError: global name 'foo' is not defined

```

From the following simple example:
```
code_string = """
def foo():
    return "foo"

def bar():
    print foo()

bar()
"""
globals_, locals_ = {}, {}

exec(code_string, globals_, locals_)
```

The code example works when run with:

```
exec(code_string, globals_)
```